### PR TITLE
test: Include relation in typeorm example

### DIFF
--- a/examples/node-typeorm/src/data-source.ts
+++ b/examples/node-typeorm/src/data-source.ts
@@ -8,6 +8,7 @@ import { StockPrice } from './models/StockPrice';
 import { DailyPageStats } from './models/DailyPageStats';
 import { StockPrice1M } from './models/candlesticks/StockPrice1M';
 import { StockPrice1H } from './models/candlesticks/StockPrice1H';
+import { Page } from './models/Page';
 
 dotenv.config();
 
@@ -16,6 +17,6 @@ export const AppDataSource = new DataSource({
   url: process.env.DATABASE_URL,
   logger: new SimpleConsoleLogger(false),
   synchronize: false,
-  entities: [PageLoad, HourlyPageViews, StockPrice, DailyPageStats, StockPrice1M, StockPrice1H],
+  entities: [Page, PageLoad, HourlyPageViews, StockPrice, DailyPageStats, StockPrice1M, StockPrice1H],
   migrations: ['migrations/*.ts'],
 });

--- a/examples/node-typeorm/src/models/Page.ts
+++ b/examples/node-typeorm/src/models/Page.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryColumn } from 'typeorm';
+
+@Entity('page')
+export class Page {
+  @PrimaryColumn({ name: 'url', type: 'varchar' })
+  url!: string;
+
+  @PrimaryColumn({ name: 'title', type: 'varchar' })
+  title!: string;
+
+  @PrimaryColumn({ name: 'content', type: 'text' })
+  content!: string;
+}

--- a/examples/node-typeorm/src/models/PageLoad.ts
+++ b/examples/node-typeorm/src/models/PageLoad.ts
@@ -1,5 +1,6 @@
-import { Entity, PrimaryColumn } from 'typeorm';
+import { Entity, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Hypertable, TimeColumn } from '@timescaledb/typeorm';
+import { Page } from './Page';
 
 @Entity('page_loads')
 @Hypertable({
@@ -18,4 +19,7 @@ export class PageLoad {
 
   @TimeColumn()
   time!: Date;
+
+  @ManyToOne(() => Page, (page) => page, { nullable: true })
+  page?: Page;
 }


### PR DESCRIPTION
This PR adds a `Page` entity to the typeorm example, so that we can test the migration hooks when using a entity that has a relation.

Related: 

* https://github.com/timescale/timescaledb-ts/pull/25

