### PR TITLE
fix: remove typesVersions at package.json

### DIFF
--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -32,13 +32,6 @@
   "bugs": {
     "url": "https://github.com/timescale/timescaledb-ts/issues"
   },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "src/*"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Hello, I'm trying to use this library in my repository. 

After following the guide and running nestjs, I'm getting the following error:
src/common/entities/request-statistics.entity.ts:2:40 - error TS2307: Cannot find module '@timescaledb/typeorm' or its corresponding type declarations.
2 import { Hypertable, TimeColumn } from '@timescaledb/typeorm';
                                         ~~~~~~~~~~~~~~~~~~~~~~
[오후 11:58:50] Found 1 error. Watching for file changes.

 It was resolved after I deleted the `typesVersions` field in `node_modules`. It seems the problem was caused by it being set to `src`.