### PR TITLE
Allow TimeColumn rename

### DIFF
--- a/packages/typeorm/src/decorators/TimeColumn.ts
+++ b/packages/typeorm/src/decorators/TimeColumn.ts
@@ -7,7 +7,7 @@ export interface TimeColumnMetadata {
   columnName: string;
 }
 
-export function TimeColumn() {
+export function TimeColumn(options?: { name?: string }) {
   return function (target: any, propertyKey: string | symbol) {
     const metadata: TimeColumnMetadata = {
       propertyKey,
@@ -16,7 +16,7 @@ export function TimeColumn() {
 
     Reflect.defineMetadata(TIME_COLUMN_METADATA_KEY, metadata, target.constructor);
 
-    PrimaryColumn({ type: 'timestamp with time zone' })(target, propertyKey);
+    PrimaryColumn({ type: 'timestamp with time zone', name: options?.name })(target, propertyKey);
   };
 }
 


### PR DESCRIPTION
This PR should allow developers to rename their `TimeColumn`s. This is key for allowing different naming conventions in databases vs code. Example: `created_at` in timescaledb vs `createdAt` in Typescript.

I'm not sure how to write a test for this addition, but would love to if someone could point me in the right direction.